### PR TITLE
Add split_array and reverse_concat functions

### DIFF
--- a/pyaldata/__init__.py
+++ b/pyaldata/__init__.py
@@ -12,3 +12,4 @@ from .smoothing import *
 from .signal_transformations import *
 from .firing_rates import *
 from .df_utils import *
+from .array_utils import *

--- a/pyaldata/array_utils.py
+++ b/pyaldata/array_utils.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def split_array(X, lengths):
+    """
+    Split an array into subarrays of given lengths along its first dimension.
+    """
+    assert np.sum(lengths) == X.shape[0]
+    
+    border_indices = np.insert(np.cumsum(lengths), 0, 0)
+    return [X[start:end, ...] for (start, end) in zip(border_indices[:-1], border_indices[1:])]

--- a/pyaldata/extract_signals.py
+++ b/pyaldata/extract_signals.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from .utils import get_trial_length
+from .array_utils import split_array
+
 
 def concat_trials(trial_data, signal, trial_indices=None):
     """
@@ -23,6 +26,28 @@ def concat_trials(trial_data, signal, trial_indices=None):
         return np.concatenate(trial_data[signal].values, axis=0)
     else:
         return np.concatenate(trial_data.loc[trial_indices, signal].values, axis=0)
+
+
+def reverse_concat(X, df):
+    """
+    Split a concatenated signal X into chunks corresponding to each trial of df.
+    ~ reverse concat_trials
+    
+    See also split_array
+    
+    Parameters
+    ----------
+    X : np.array
+        concatenated signal
+    df : pd.DataArray
+        dataframe from which the signal was extracted by concatenating the trials
+        
+    Returns
+    -------
+    list of subarrays
+    """
+    trial_lengths = [get_trial_length(trial) for (i, trial) in df.iterrows()]
+    return split_array(X, trial_lengths)
 
 
 def get_signals(trial_data, signals, trial_indices=None):


### PR DESCRIPTION
- `split_array` splits an array along its first dimension into chunks of given lengths
- `reverse_concat` uses `split_array` to split a concatenated signal back to smaller arrays for each trial