### PR TITLE
Improve `get_time_varying_fields`

### DIFF
--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -90,7 +90,7 @@ def get_time_varying_fields(
     trial_data: pd.DataFrame,
     ref_field: str = None,
     strict_criterion: bool = True,
-    warn_if_suspicious: bool = False,
+    warn_if_suspicious: bool = True,
 ):
     """
     Identify time-varying fields in the dataset
@@ -110,7 +110,7 @@ def get_time_varying_fields(
         it has to contain numpy arrays and the first dimension of the arrays has to match
         the reference field on all trials
 
-    warn_if_suspicious: bool, default False
+    warn_if_suspicious: bool, default True
         only used if strict_criterion is True.
         if a field contains numpy arrays and has the same length as the reference field
         on 80% of the trials, it might be a time-varying field with some errors.

--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -1,14 +1,15 @@
-import numpy as np
-import pandas as pd
-
 import functools
 import warnings
+
+import numpy as np
+import pandas as pd
 
 
 def copy_td(func):
     """
     Call copy on the first argument of the function and work on the copied value
     """
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # if there are no positional arguments
@@ -16,14 +17,18 @@ def copy_td(func):
             df = kwargs["trial_data"]
 
             if not isinstance(df, pd.DataFrame):
-                raise ValueError(f"first argument of {func.__name__} has to be a pandas DataFrame")
+                raise ValueError(
+                    f"first argument of {func.__name__} has to be a pandas DataFrame"
+                )
 
             kwargs["trial_data"] = df.copy()
             return func(**kwargs)
         else:
             # dataframe is the first positional argument
             if not isinstance(args[0], pd.DataFrame):
-                raise ValueError(f"first argument of {func.__name__} has to be a pandas DataFrame")
+                raise ValueError(
+                    f"first argument of {func.__name__} has to be a pandas DataFrame"
+                )
 
             return func(args[0].copy(), *args[1:], **kwargs)
 
@@ -48,14 +53,18 @@ def remove_suffix(text, suffix):
         text untouched if text doesn't end with suffix
     """
     if text.endswith(suffix):
-        return text[:-len(suffix)]
+        return text[: -len(suffix)]
     else:
         warnings.warn(f"{text} doesn't end with {suffix}. Didn't remove anything.")
     return text
 
 
-  
-def get_time_varying_fields(trial_data, ref_field=None):
+def get_time_varying_fields(
+    trial_data,
+    ref_field=None,
+    strict_criterion: bool = True,
+    warn_if_suspicious: bool = False,
+):
     """
     Identify time-varying fields in the dataset
 
@@ -69,6 +78,19 @@ def get_time_varying_fields(trial_data, ref_field=None):
         time-varying field to use for identifying the rest
         if not given, the first field that ends with "spikes" or "rates" is used
 
+    strict_criterion: bool, default True
+        in order for a column to qualify as time-varying,
+        it has to contain numpy arrays and the first dimension of the arrays has to match
+        the reference field on all trials
+
+    warn_if_suspicious: bool, default False
+        only used if strict_criterion is True.
+        if a field contains numpy arrays and has the same length as the reference field
+        on 80% of the trials, it might be a time-varying field with some errors.
+        set this to true to check and warn if a field like that is found
+        if strict_criterion is False, such fields are likely to cause an error
+
+
     Returns
     -------
     time_fields : list of str
@@ -76,25 +98,49 @@ def get_time_varying_fields(trial_data, ref_field=None):
     """
     if ref_field is None:
         # look for a spikes field
-        ref_field = [col for col in trial_data.columns.values
-                     if col.endswith("spikes") or col.endswith("rates")][0]
+        ref_field = [
+            col
+            for col in trial_data.columns.values
+            if col.endswith("spikes") or col.endswith("rates")
+        ][0]
 
-    # identify candidates based on the first trial
-    first_trial = trial_data.iloc[0]
-    T = first_trial[ref_field].shape[0]
     time_fields = []
-    for col in first_trial.index:
-        try:
-            if first_trial[col].shape[0] == T:
-                time_fields.append(col)
-        except:
-            pass
 
-    # but check the rest of the trials, too
-    ref_lengths = np.array([arr.shape[0] for arr in trial_data[ref_field]])
-    for col in time_fields:
-        col_lengths = np.array([arr.shape[0] for arr in trial_data[col]])
-        assert np.all(col_lengths == ref_lengths), f"not all lengths in {col} match the reference {ref_field}"
+    if strict_criterion:
+        required_match_ratio = 0.8
+
+        ref_lengths = np.array([arr.shape[0] for arr in trial_data[ref_field]])
+
+        for col in get_array_fields(trial_data):
+            col_lengths = np.array([arr.shape[0] for arr in trial_data[col]])
+            if np.all(col_lengths == ref_lengths):
+                time_fields.append(col)
+            elif warn_if_suspicious:
+                match_ratio = np.mean(col_lengths == ref_lengths)
+                if match_ratio >= required_match_ratio:
+                    warnings.warn(
+                        f"{col} might be a time-varying field. It matches the length of {ref_field} on {match_ratio*100}% of trials"
+                    )
+    else:
+        # use the old method
+
+        # identify candidates based on the first trial
+        first_trial = trial_data.iloc[0]
+        T = first_trial[ref_field].shape[0]
+        for col in first_trial.index:
+            try:
+                if first_trial[col].shape[0] == T:
+                    time_fields.append(col)
+            except:
+                pass
+
+        # but check the rest of the trials, too
+        ref_lengths = np.array([arr.shape[0] for arr in trial_data[ref_field]])
+        for col in time_fields:
+            col_lengths = np.array([arr.shape[0] for arr in trial_data[col]])
+            assert np.all(
+                col_lengths == ref_lengths
+            ), f"not all lengths in {col} match the reference {ref_field}"
 
     return time_fields
 
@@ -112,7 +158,11 @@ def get_array_fields(trial_data):
     -------
     columns that have array values : list of str
     """
-    return [col for col in trial_data.columns if all([isinstance(el, np.ndarray) for el in trial_data[col]])]
+    return [
+        col
+        for col in trial_data.columns
+        if all([isinstance(el, np.ndarray) for el in trial_data[col]])
+    ]
 
 
 def get_string_fields(trial_data):
@@ -128,7 +178,11 @@ def get_string_fields(trial_data):
     -------
     columns that have string values : list of str
     """
-    return [col for col in trial_data.columns if all([isinstance(el, str) for el in trial_data[col]])]
+    return [
+        col
+        for col in trial_data.columns
+        if all([isinstance(el, str) for el in trial_data[col]])
+    ]
 
 
 def get_trial_length(trial, ref_field=None):
@@ -148,7 +202,10 @@ def get_trial_length(trial, ref_field=None):
     length : int
     """
     if ref_field is None:
-        ref_field = [col for col in trial.index.values if col.endswith("spikes") or col.endswith("rates")][0]
+        ref_field = [
+            col
+            for col in trial.index.values
+            if col.endswith("spikes") or col.endswith("rates")
+        ][0]
 
     return np.size(trial[ref_field], axis=0)
-

--- a/tests/test_determine_ref_field.py
+++ b/tests/test_determine_ref_field.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyaldata.utils import determine_ref_field
+
+# default number of timepoints
+T = 50
+# number of trials
+N = 13
+
+
+def _generate_mock_data(
+    correct_spikes: bool = False,
+    correct_rates: bool = False,
+    incorrect_on_all_trials_rates: bool = False,
+    incorrect_on_one_trial_rates: bool = False,
+    correct_pos: bool = False,
+    incorrect_on_all_trials_pos: bool = False,
+    incorrect_on_one_trial_pos: bool = False,
+):
+    data = {}
+
+    rng = np.random.default_rng()
+
+    data["pmd_spikes"] = [rng.standard_normal((T, 100)) for _ in range(N)]
+    data["some_string_field"] = ["asdf" for _ in range(N)]
+    data["some_int_field"] = [rng.integers(0, 10) for _ in range(N)]
+
+    if correct_spikes:
+        data["correct_spikes"] = [rng.standard_normal((T, 10)) for _ in range(N)]
+
+    if correct_rates:
+        data["correct_rates"] = [rng.standard_normal((T, 10)) for _ in range(N)]
+
+    if incorrect_on_all_trials_rates:
+        data["incorrect_on_all_trials_rates"] = [
+            rng.standard_normal((T - 10, 10)) for _ in range(N)
+        ]
+
+    if incorrect_on_one_trial_rates:
+        arrays = [rng.standard_normal((T, 10)) for _ in range(N)]
+        arrays[11] = arrays[11][: T - 10, :]
+        data["incorrect_on_one_trial_rates"] = arrays
+
+    if correct_pos:
+        data["correct_pos"] = [rng.standard_normal((T, 2)) for _ in range(N)]
+
+    if incorrect_on_all_trials_pos:
+        data["incorrect_on_all_trials_pos"] = [
+            rng.standard_normal((T - 10, 2)) for _ in range(N)
+        ]
+
+    if incorrect_on_one_trial_pos:
+        arrays = [rng.standard_normal((T, 2)) for _ in range(N)]
+        arrays[11] = arrays[11][: T - 10, :]
+        data["incorrect_on_one_trial_pos"] = arrays
+
+    return pd.DataFrame(data)
+
+
+def test_one_field():
+    df = _generate_mock_data()
+
+    assert determine_ref_field(df) == "pmd_spikes"
+
+
+def test_correct_spikes():
+    df = _generate_mock_data(correct_spikes=True)
+
+    assert determine_ref_field(df) in ["pmd_spikes", "correct_spikes"]
+
+
+def test_correct_rates():
+    df = _generate_mock_data(correct_rates=True)
+
+    assert determine_ref_field(df) in ["pmd_spikes", "correct_rates"]
+
+
+def test_incorrect_on_all_trials_rates():
+    df = _generate_mock_data(incorrect_on_all_trials_rates=True)
+
+    with pytest.raises(ValueError):
+        determine_ref_field(df)
+
+
+def test_incorrect_on_one_trial_rates():
+    df = _generate_mock_data(incorrect_on_one_trial_rates=True)
+
+    with pytest.raises(ValueError):
+        determine_ref_field(df)

--- a/tests/test_get_time_varying_fields.py
+++ b/tests/test_get_time_varying_fields.py
@@ -58,7 +58,8 @@ def test_strict_warn_if_suspicios():
     df = _generate_mock_data(incorrect_on_one_trial_pos=True)
 
     with pytest.warns():
-        get_time_varying_fields(df, warn_if_suspicious=True)
+        # get_time_varying_fields(df, warn_if_suspicious=True)
+        get_time_varying_fields(df)
 
 
 def test_strict_no_warning_if_not_wanted():
@@ -67,7 +68,7 @@ def test_strict_no_warning_if_not_wanted():
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        get_time_varying_fields(df)
+        get_time_varying_fields(df, warn_if_suspicious=False)
 
 
 def test_strict_wrong_ref_field_given():

--- a/tests/test_get_time_varying_fields.py
+++ b/tests/test_get_time_varying_fields.py
@@ -86,8 +86,10 @@ def test_strict_other_ref_field():
         incorrect_on_all_trials_rates=True, incorrect_on_all_trials_pos=True
     )
 
-    with pytest.raises(ValueError):
-        get_time_varying_fields(df)
+    assert set(get_time_varying_fields(df, ref_field="incorrect_on_all_trials_rates")) == {
+        "incorrect_on_all_trials_rates",
+        "incorrect_on_all_trials_pos",
+    }
 
 
 def test_old_correct():

--- a/tests/test_get_time_varying_fields.py
+++ b/tests/test_get_time_varying_fields.py
@@ -1,0 +1,102 @@
+import warnings
+
+import pytest
+
+from pyaldata.utils import get_time_varying_fields
+
+from .test_determine_ref_field import _generate_mock_data
+
+
+def test_strict_correct_single_field():
+    # only time-varying field is pmd_spikes
+    df = _generate_mock_data()
+
+    assert get_time_varying_fields(df) == ["pmd_spikes"]
+
+
+def test_strict_correct_spikes_rates():
+    # two other correct spikes/rates fields should also be included
+    df = _generate_mock_data(correct_spikes=True, correct_rates=True)
+
+    assert set(get_time_varying_fields(df)) == {
+        "pmd_spikes",
+        "correct_spikes",
+        "correct_rates",
+    }
+
+
+def test_strict_correct_pos():
+    # a position field that has the correct time length should be included
+    df = _generate_mock_data(correct_spikes=True, correct_pos=True)
+
+    assert set(get_time_varying_fields(df)) == {
+        "pmd_spikes",
+        "correct_spikes",
+        "correct_pos",
+    }
+
+
+def test_strict_incorrect_rates():
+    # a rates field that has the wrong length on every trial should raise an error
+    df = _generate_mock_data(incorrect_on_one_trial_rates=True)
+
+    with pytest.raises(ValueError):
+        get_time_varying_fields(df)
+
+
+def test_strict_incorrect_pos_not_there():
+    # a position field that has incorrect length on each trial should not be included
+    df = _generate_mock_data(incorrect_on_all_trials_pos=True)
+
+    assert get_time_varying_fields(df) == ["pmd_spikes"]
+
+
+def test_strict_warn_if_suspicios():
+    # if there is a position field that is the correct length on most of the trials
+    # and warn_if_suspicious is True
+    # then make sure a warning is given
+    df = _generate_mock_data(incorrect_on_one_trial_pos=True)
+
+    with pytest.warns():
+        get_time_varying_fields(df, warn_if_suspicious=True)
+
+
+def test_strict_no_warning_if_not_wanted():
+    # if warn_if_suspicious is False, there should be no warning
+    df = _generate_mock_data(incorrect_on_one_trial_pos=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        get_time_varying_fields(df)
+
+
+def test_strict_wrong_ref_field_given():
+    # raise an error if the ref_field given is not in the dataframe
+    df = _generate_mock_data()
+
+    with pytest.raises(KeyError):
+        get_time_varying_fields(df, ref_field="m1_spikes")
+
+
+def test_strict_other_ref_field():
+    # these two fields will have the same number of timepoints on all trials
+    # but pmd_spikes is not the same,
+    # so an error should be raised because all spikes/rates should match each other
+    df = _generate_mock_data(
+        incorrect_on_all_trials_rates=True, incorrect_on_all_trials_pos=True
+    )
+
+    with pytest.raises(ValueError):
+        get_time_varying_fields(df)
+
+
+def test_old_correct():
+    # from the old behavior only test the happy path
+    df = _generate_mock_data(correct_spikes=True, correct_rates=True, correct_pos=True)
+
+    assert set(get_time_varying_fields(df, strict_criterion=False)) == {
+        "pmd_spikes",
+        "correct_spikes",
+        "correct_rates",
+        "correct_pos",
+    }

--- a/tests/test_get_trial_length.py
+++ b/tests/test_get_trial_length.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pyaldata.utils import get_trial_length
+
+from .test_determine_ref_field import T, _generate_mock_data
+
+
+def test_single_field():
+    df = _generate_mock_data()
+
+    assert get_trial_length(df.iloc[0]) == T
+
+
+def test_correct_multiple():
+    df = _generate_mock_data(correct_rates=True, correct_spikes=True)
+
+    assert get_trial_length(df.iloc[0]) == T
+
+
+def test_inconsistent_lengths():
+    df = _generate_mock_data(incorrect_on_all_trials_rates=True)
+
+    with pytest.raises(ValueError):
+        get_trial_length(df.iloc[0])


### PR DESCRIPTION
Change the behavior such that:
- in `get_trial_length` if no explicit reference field is given, throw an error if not all spikes / rates fields have the same length because then the reference length is ambiguous
- same for `get_time_varying_fields`: without an explicit reference field, all spikes / rates fields have to be the same length on all trials
- `get_time_varying_fields` warns if there is a field that has arrays as its elements and has the same length on the first dimension as the reference field on at least 80% of trials
- the old behavior of `get_time_varying_fields` (identifying candidate fields on the first trial and throwing an error if they don't match on other trials) can be accessed passing `strict_criterion=False`