### PR TITLE
Add `get_trial_lengths` and extend `get_trial_length` to handle dataframes

### DIFF
--- a/pyaldata/__init__.py
+++ b/pyaldata/__init__.py
@@ -71,5 +71,6 @@ from .utils import (
     get_string_fields,
     get_time_varying_fields,
     get_trial_length,
+    get_trial_lengths,
     remove_suffix,
 )

--- a/tests/test_get_trial_length.py
+++ b/tests/test_get_trial_length.py
@@ -1,8 +1,10 @@
+import numpy as np
+import pandas as pd
 import pytest
 
-from pyaldata.utils import get_trial_length
+from pyaldata.utils import get_trial_length, get_trial_lengths
 
-from .test_determine_ref_field import T, _generate_mock_data
+from .test_determine_ref_field import N, T, _generate_mock_data
 
 
 def test_single_field():
@@ -22,3 +24,43 @@ def test_inconsistent_lengths():
 
     with pytest.raises(ValueError):
         get_trial_length(df.iloc[0])
+
+
+def test_get_trial_lengths_all_the_same():
+    df = _generate_mock_data()
+
+    expected = T * np.ones(df.shape[0])
+
+    assert np.all(get_trial_lengths(df) == expected)
+
+
+def test_get_trial_lengths_random_lengths():
+    trial_lengths = np.random.randint(0, T, size=N)
+
+    data = {}
+    data["pmd_spikes"] = [np.random.normal(size=(l, 100)) for l in trial_lengths]
+    df = pd.DataFrame(data)
+
+    assert np.all(get_trial_lengths(df) == trial_lengths)
+
+
+def test_get_trial_length_df_happy():
+    df = _generate_mock_data(correct_rates=True, correct_spikes=True)
+
+    assert get_trial_length(df) == T
+
+
+def test_get_trial_length_df_different_lengths():
+    trial_lengths = np.random.randint(0, T, size=N)
+
+    data = {}
+    data["pmd_spikes"] = [np.random.normal(size=(l, 100)) for l in trial_lengths]
+    df = pd.DataFrame(data)
+
+    with pytest.raises(ValueError, match="All trials must have the same length."):
+        get_trial_length(df)
+
+
+def test_get_trial_length_df_wrong_type():
+    with pytest.raises(TypeError):
+        get_trial_length([1, 2, 3])


### PR DESCRIPTION
- `get_trial_lengths` returns an array of trial lengths in the dataframe
- `get_trial_length` can be applied to dataframes. It returns a single value if all the trials have the same length, and raises an error otherwise