### PR TITLE
Require all elements of a field to be 0d arrays for converting to scalar

### DIFF
--- a/pyaldata/data_cleaning.py
+++ b/pyaldata/data_cleaning.py
@@ -30,7 +30,7 @@ def backshift_idx_fields(trial_data: pd.DataFrame):
 
 
 @utils.copy_td
-def clean_0d_array_fields(df: pd.DataFrame):
+def clean_0d_array_fields(df: pd.DataFrame) -> pd.DataFrame:
     """
     Loading v7.3 MAT files, sometimes scalers are stored as 0-dimensional arrays for some reason.
     This converts those back to scalars.
@@ -45,7 +45,7 @@ def clean_0d_array_fields(df: pd.DataFrame):
     a copy of df with the relevant fields changed
     """
     for c in df.columns:
-        if isinstance(df[c].values[0], np.ndarray):
+        if all(isinstance(el, np.ndarray) for el in df[c].values):
             if all([arr.ndim == 0 for arr in df[c]]):
                 df[c] = [arr.item() for arr in df[c]]
 

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+from pyaldata.data_cleaning import clean_0d_array_fields
+
+from .test_determine_ref_field import _generate_mock_data
+
+
+def test_clean_0d_array_fields_int_only():
+    # if the field is already just scalars, it should not be changed
+    df = _generate_mock_data()
+    idx_vals = [5 for _ in range(df.shape[0])]
+    df["idx_field"] = idx_vals
+
+    assert clean_0d_array_fields(df)["idx_field"].tolist() == idx_vals
+
+
+def test_clean_0d_array_fields_0d_only():
+    # if the field is only 0d arrays, they should be converted to scalars
+    df = _generate_mock_data()
+    idx_vals_scalar = [5 for _ in range(df.shape[0])]
+    df["idx_field"] = [np.array(val) for val in idx_vals_scalar]
+
+    assert clean_0d_array_fields(df)["idx_field"].tolist() == idx_vals_scalar
+
+
+def test_clean_0d_array_fields_1d_only():
+    # if the field is only 1d arrays, they should be left alone
+    df = _generate_mock_data()
+    idx_vals_scalar = [5 for _ in range(df.shape[0])]
+    idx_vals_1d_array = [np.array([val]) for val in idx_vals_scalar]
+    df["idx_field"] = idx_vals_1d_array
+
+    assert clean_0d_array_fields(df)["idx_field"].tolist() == idx_vals_1d_array
+
+
+def test_clean_0d_array_fields_first_element_0d():
+    df = _generate_mock_data()
+    idx_vals_scalar = [5 for _ in range(df.shape[0])]
+
+    idx_vals_mixed = [val for val in idx_vals_scalar]
+    idx_vals_mixed[0] = np.array(idx_vals_mixed[0])  # first element is 0d
+
+    df["idx_field"] = idx_vals_mixed
+
+    assert clean_0d_array_fields(df)["idx_field"].tolist() == idx_vals_mixed
+
+
+def test_clean_0d_array_fields_first_mixed():
+    df = _generate_mock_data()
+    idx_vals_scalar = [5 for _ in range(df.shape[0])]
+
+    idx_vals_mixed = [val for val in idx_vals_scalar]
+
+    idx_vals_mixed[2] = np.array([idx_vals_mixed[2], idx_vals_mixed[2] * 2])
+    idx_vals_mixed[1] = np.array(idx_vals_mixed[1])
+
+    df["idx_field"] = idx_vals_mixed
+
+    assert clean_0d_array_fields(df)["idx_field"].tolist() == idx_vals_mixed


### PR DESCRIPTION
`clean_0d_array_fields` only checked the first element of a column.

@martinesparza has a use case where some elements of a column are 0D arrays, so scalars, some 1D arrays.
If the first element is a 0D array, but the others aren't, checking the element's `ndim` throws an error.
This fixes that by only converting columns where all elements are 0D arrays.