### PR TITLE
scipy.signal.gaussian was moved to scipy.signal.windows.gaussian

### DIFF
--- a/pyaldata/smoothing.py
+++ b/pyaldata/smoothing.py
@@ -29,7 +29,7 @@ def norm_gauss_window(bin_length: float, std: float) -> np.ndarray:
             length: 10*std/bin_length
             mass normalized to 1
     """
-    win = scs.gaussian(int(10 * std / bin_length), std / bin_length)
+    win = scs.windows.gaussian(int(10 * std / bin_length), std / bin_length)
     return win / np.sum(win)
 
 


### PR DESCRIPTION
scipy moved the window functions to `scipy.signal.windows` and deprecated `scipy.signal.gaussian`